### PR TITLE
Add basic @ManyToOne support

### DIFF
--- a/jfleet-core/src/main/java/org/jfleet/FieldInfo.java
+++ b/jfleet-core/src/main/java/org/jfleet/FieldInfo.java
@@ -45,7 +45,7 @@ public class FieldInfo {
         this.fieldType = fieldType;
     }
 
-    public FieldInfo prepend(String name) {
+    public FieldInfo prependName(String name) {
         FieldInfo newOne = new FieldInfo();
         newOne.fieldType = fieldType;
         newOne.columnName = columnName;

--- a/jfleet-core/src/test/java/org/jfleet/FailedManyToOneEntityInspectorTest.java
+++ b/jfleet-core/src/test/java/org/jfleet/FailedManyToOneEntityInspectorTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2017 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jfleet;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumns;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToOne;
+
+import org.jfleet.EntityFieldType.FieldTypeEnum;
+import org.junit.Test;
+
+public class FailedManyToOneEntityInspectorTest {
+
+    @Entity
+    public class NotIdentified {
+
+        private Long id;
+        private String name;
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+    }
+
+    @Entity
+    public class Foo {
+
+        @Id
+        private Long id;
+        @ManyToOne
+        private NotIdentified reference;
+
+        public Long getId() {
+            return id;
+        }
+
+        public NotIdentified getReference() {
+            return reference;
+        }
+
+    }
+
+    @Entity
+    public class Bar {
+
+        @Id
+        private String uuid;
+
+        @ManyToOne
+        @JoinTable(name = "some_table")
+        private Foo foo;
+
+        public String getUuid() {
+            return uuid;
+        }
+
+        public Foo getFoo() {
+            return foo;
+        }
+
+    }
+
+    @Entity
+    public class FooBar {
+
+        @Id
+        private int serialId;
+
+        @ManyToOne
+        @JoinColumns(value= {})
+        private Foo foo;
+
+        public int getSerialId() {
+            return serialId;
+        }
+
+        public Foo getFoo() {
+            return foo;
+        }
+    }
+
+    @Test
+    public void nonIdentifiedIsNotMapped() {
+        JpaEntityInspector inspector = new JpaEntityInspector(Foo.class);
+        EntityInfo entityInfo = inspector.inspect();
+
+        assertEquals(1, entityInfo.getFields().size());
+        FieldInfo id = entityInfo.getFields().get(0);
+        assertEquals(FieldTypeEnum.LONG, id.getFieldType().getFieldType());
+        assertEquals("id", id.getColumnName());
+    }
+
+    @Test
+    public void joinTableIsNotMapped() {
+        JpaEntityInspector inspector = new JpaEntityInspector(Bar.class);
+        EntityInfo entityInfo = inspector.inspect();
+
+        assertEquals(1, entityInfo.getFields().size());
+        FieldInfo id = entityInfo.getFields().get(0);
+        assertEquals(FieldTypeEnum.STRING, id.getFieldType().getFieldType());
+        assertEquals("uuid", id.getColumnName());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void joinColumnsIsNotMapped() {
+        JpaEntityInspector inspector = new JpaEntityInspector(FooBar.class);
+        EntityInfo entityInfo = inspector.inspect();
+
+        assertEquals(1, entityInfo.getFields().size());
+        FieldInfo id = entityInfo.getFields().get(0);
+        assertEquals(FieldTypeEnum.INT, id.getFieldType().getFieldType());
+        assertEquals("serialId", id.getColumnName());
+    }
+
+}

--- a/jfleet-core/src/test/java/org/jfleet/ManyToOneEntityInspectorTest.java
+++ b/jfleet-core/src/test/java/org/jfleet/ManyToOneEntityInspectorTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2017 Jerónimo López Bezanilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jfleet;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import org.jfleet.EntityFieldType.FieldTypeEnum;
+import org.junit.Test;
+
+public class ManyToOneEntityInspectorTest {
+
+    @Entity
+    public class Product {
+
+        @Id
+        private Long id;
+        private String name;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+    }
+
+    @Entity
+    public class Sku {
+
+        @Id
+        private Long id;
+        private String reference;
+        @ManyToOne
+        private Product product;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public String getReference() {
+            return reference;
+        }
+
+        public void setReference(String reference) {
+            this.reference = reference;
+        }
+
+        public Product getProduct() {
+            return product;
+        }
+
+        public void setProduct(Product product) {
+            this.product = product;
+        }
+
+    }
+
+
+    @Entity
+    public class Foo {
+
+        @Id
+        private Long id;
+        @ManyToOne
+        @JoinColumn(name = "foo_id_product_fk")
+        private Product productRef;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public Product getProductRef() {
+            return productRef;
+        }
+
+        public void setProduct(Product productRef) {
+            this.productRef = productRef;
+        }
+
+    }
+
+    @Test
+    public void inspectAnEntityWithManyToOneRelationShip() {
+        JpaEntityInspector inspector = new JpaEntityInspector(Sku.class);
+        EntityInfo entityInfo = inspector.inspect();
+
+        FieldInfo id = getField(entityInfo, "id");
+        assertEquals(FieldTypeEnum.LONG, id.getFieldType().getFieldType());
+        assertEquals("id", id.getColumnName());
+
+        FieldInfo name = getField(entityInfo, "reference");
+        assertEquals(FieldTypeEnum.STRING, name.getFieldType().getFieldType());
+        assertEquals("reference", name.getColumnName());
+
+        FieldInfo street = getField(entityInfo, "product.id");
+        assertEquals(FieldTypeEnum.LONG, street.getFieldType().getFieldType());
+        assertEquals("product_id", street.getColumnName());
+    }
+
+
+    @Test
+    public void inspectAnEntityWithManyToOneJoinColumn() {
+        JpaEntityInspector inspector = new JpaEntityInspector(Foo.class);
+        EntityInfo entityInfo = inspector.inspect();
+
+        FieldInfo id = getField(entityInfo, "id");
+        assertEquals(FieldTypeEnum.LONG, id.getFieldType().getFieldType());
+        assertEquals("id", id.getColumnName());
+
+        FieldInfo street = getField(entityInfo, "productRef.id");
+        assertEquals(FieldTypeEnum.LONG, street.getFieldType().getFieldType());
+        assertEquals("foo_id_product_fk", street.getColumnName());
+    }
+
+    private FieldInfo getField(EntityInfo entityInfo, String fieldName) {
+        return entityInfo.getFields().stream().filter(f -> f.getFieldName().equals(fieldName)).findFirst().get();
+    }
+
+}

--- a/jfleet-core/src/test/java/org/jfleet/shared/ManyToOnePersistenceTest.java
+++ b/jfleet-core/src/test/java/org/jfleet/shared/ManyToOnePersistenceTest.java
@@ -1,0 +1,232 @@
+package org.jfleet.shared;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.jfleet.BulkInsert;
+import org.jfleet.JFleetException;
+import org.jfleet.util.SqlUtil;
+import org.junit.Test;
+
+public class ManyToOnePersistenceTest extends AllDatabasesBaseTest {
+
+    @Entity
+    public class Product {
+
+        @Id
+        private Long id;
+        private String name;
+
+        public Product(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+    }
+
+    @Entity
+    @Table(name = "tesla")
+    public class Foo {
+
+        @Id
+        private Long id;
+        private String reference;
+        @ManyToOne
+        private Product product;
+
+        public Foo(Long id, String reference, Product product) {
+            this.id = id;
+            this.reference = reference;
+            this.product = product;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getReference() {
+            return reference;
+        }
+
+        public Product getProduct() {
+            return product;
+        }
+
+    }
+
+    @Entity
+    @Table(name = "textil")
+    public class Bar {
+
+        @Id
+        private Long id;
+        private double price;
+        @ManyToOne
+        @JoinColumn(name = "alternate_id")
+        private Product product;
+
+        public Bar(Long id, double price, Product product) {
+            this.id = id;
+            this.price = price;
+            this.product = product;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public double getPrice() {
+            return price;
+        }
+
+        public Product getProduct() {
+            return product;
+        }
+
+    }
+
+    @Test
+    public void canPersistAnEntityWithManyToOne() throws JFleetException, SQLException, IOException {
+        Product p1 = new Product(1L, "Tesla X");
+        Foo f1 = new Foo(1L, "85H", p1);
+        Foo f2 = new Foo(2L, "100H", p1);
+        Product p2 = new Product(2L, "Tesla S");
+        Foo f3 = new Foo(3L, "120H", p2);
+
+        List<Foo> foos = Arrays.asList(f1, f2, f3);
+
+        BulkInsert<Foo> insert = database.getBulkInsert(Foo.class);
+        try (Connection conn = database.getConnection()) {
+            SqlUtil.createTableForEntity(conn, Foo.class);
+            insert.insertAll(conn, foos);
+
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT id, reference, product_id FROM tesla ORDER BY id ASC")) {
+                    for (Foo f : foos) {
+                        assertTrue(rs.next());
+                        assertEquals(f.getId().longValue(), rs.getLong("id"));
+                        assertEquals(f.getReference(), rs.getString("reference"));
+                        assertEquals(f.getProduct().getId().longValue(), rs.getLong("product_id"));
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void canPersistAnEntityWithJoinColumn() throws JFleetException, SQLException, IOException {
+        Product p1 = new Product(1L, "Gocco");
+        Bar f1 = new Bar(1L, 10.95, p1);
+        Bar f2 = new Bar(2L, 14.95, p1);
+        Product p2 = new Product(2L, "Amichi");
+        Bar f3 = new Bar(3L, 4.95, p2);
+
+        List<Bar> bars = Arrays.asList(f1, f2, f3);
+
+        BulkInsert<Bar> insert = database.getBulkInsert(Bar.class);
+        try (Connection conn = database.getConnection()) {
+            SqlUtil.createTableForEntity(conn, Bar.class);
+            insert.insertAll(conn, bars);
+
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT id, price, alternate_id FROM textil ORDER BY id ASC")) {
+                    for (Bar f : bars) {
+                        assertTrue(rs.next());
+                        assertEquals(f.getId().longValue(), rs.getLong("id"));
+                        assertEquals(f.getPrice(), rs.getDouble("price"),0.0001);
+                        assertEquals(f.getProduct().getId().longValue(), rs.getLong("alternate_id"));
+                    }
+                }
+            }
+        }
+    }
+
+    /*
+     * If referenced entity has no id assigned, JFleet doesn't persist the entity (as JPA does) and doesn't assign
+     * the Id. The main entity then is persisted without the id of the referenced entity.
+     * JFleet user must persist or load any entity referenced, or assign manually an id.
+     */
+    @Test
+    public void canPersistAnEntityWithManyToOneNullId() throws JFleetException, SQLException, IOException {
+        Product p1 = new Product(1L, "Gocco");
+        Bar f1 = new Bar(1L, 10.95, p1);
+        Product p2 = new Product(null, "Amichi");
+        Bar f2 = new Bar(2L, 14.95, p2);
+
+        List<Bar> bars = Arrays.asList(f1, f2);
+
+        BulkInsert<Bar> insert = database.getBulkInsert(Bar.class);
+        try (Connection conn = database.getConnection()) {
+            SqlUtil.createTableForEntity(conn, Bar.class);
+            insert.insertAll(conn, bars);
+
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT id, price, alternate_id FROM textil ORDER BY id ASC")) {
+                    assertTrue(rs.next());
+                    assertEquals(f1.getId().longValue(), rs.getLong("id"));
+                    assertEquals(f1.getPrice(), rs.getDouble("price"),0.0001);
+                    assertEquals(f1.getProduct().getId().longValue(), rs.getLong("alternate_id"));
+
+                    assertTrue(rs.next());
+                    assertEquals(f2.getId().longValue(), rs.getLong("id"));
+                    assertEquals(f2.getPrice(), rs.getDouble("price"),0.0001);
+                    rs.getLong("alternate_id");
+                    assertTrue(rs.wasNull());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void canPersistAnEntityWithManyToOneNullReference() throws JFleetException, SQLException, IOException {
+        Product p1 = new Product(1L, "Gocco");
+        Bar f1 = new Bar(1L, 10.95, p1);
+        Bar f2 = new Bar(2L, 14.95, null);
+
+        List<Bar> bars = Arrays.asList(f1, f2);
+
+        BulkInsert<Bar> insert = database.getBulkInsert(Bar.class);
+        try (Connection conn = database.getConnection()) {
+            SqlUtil.createTableForEntity(conn, Bar.class);
+            insert.insertAll(conn, bars);
+
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT id, price, alternate_id FROM textil ORDER BY id ASC")) {
+                    assertTrue(rs.next());
+                    assertEquals(f1.getId().longValue(), rs.getLong("id"));
+                    assertEquals(f1.getPrice(), rs.getDouble("price"),0.0001);
+                    assertEquals(f1.getProduct().getId().longValue(), rs.getLong("alternate_id"));
+
+                    assertTrue(rs.next());
+                    assertEquals(f2.getId().longValue(), rs.getLong("id"));
+                    assertEquals(f2.getPrice(), rs.getDouble("price"),0.0001);
+                    rs.getLong("alternate_id");
+                    assertTrue(rs.wasNull());
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Add support to ManyToOne #2  relationship with only one column foreign key.
JoinTable and JoinColumns annotations are not supported.
The referenced entity MUST HAVE a value in the @id attribute. JFleet doesn't persist related entities and if the id field has no value, the FK column will be null.



